### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Handle line endings automatically for files detected as text
+* text=auto


### PR DESCRIPTION
For in case git's core setting are different, so line ending are auto handled. Same as the Fix/gitattributes for line endings #36 on the backend Repo